### PR TITLE
Allow int/bigint columns to have missing values without converting to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.3.1](https://github.com/dataiku/dss-plugin-neo4j/tree/v1.3.1) - Bugfix release - 2021-11
 
-- Allow missing values in int columns (instead of converting to float)
+- Allow missing values in int columns (instead of raising a specific error message)
 
 ## [Version 1.3.0](https://github.com/dataiku/dss-plugin-neo4j/tree/v1.3.0) - Feature improvements release - 2021-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.3.1](https://github.com/dataiku/dss-plugin-neo4j/tree/v1.3.1) - Bugfix release - 2021-11
+
+- Allow missing values in int columns (instead of converting to float)
+
 ## [Version 1.3.0](https://github.com/dataiku/dss-plugin-neo4j/tree/v1.3.0) - Feature improvements release - 2021-04
 
 ### General

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "neo4j",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "meta": {
         "label": "Neo4j",
         "description": "Interact with the Neo4j graph database",


### PR DESCRIPTION
Before it failed on integer columns with missing values (with the error ""Integer column has NA values in column ") because infer_with_pandas was False and pandas doesn't support missing values in integer.
Now, int are casted to np.object_ because they can have missing values but are still interpreted as integer by neo4j 